### PR TITLE
#162183706 Modify incident location endpoint

### DIFF
--- a/server/controller/controller.js
+++ b/server/controller/controller.js
@@ -31,7 +31,7 @@ class Incidents {
      * @async oneIncident
      * @param {*} req
      * @param {*} res
-     * @returns record
+     * @returns {object} record
      */
     static async oneIncident(req, res) {
         const id = parseInt(req.params.id, 10);
@@ -58,7 +58,7 @@ class Incidents {
      * @class createIncident
      * @param {*} req
      * @param {*} res
-     * @returns newRecord
+     * @returns {object} newRecord
      */
     static async createIncident(req, res) {
         try {
@@ -77,6 +77,37 @@ class Incidents {
             });
         } catch (error) {
             return res.status(400).send({
+                message: error,
+            });
+        }
+    }
+
+    /**
+     * @async modifyIncidentLocation
+     * @param {*} req
+     * @param {*} res
+     * @returns {object} modifiedRecord
+     */
+    static async modifyIncidentLocation(req, res) {
+        const id = parseInt(req.params.id, 10);
+        try {
+            const record = await Model.getOne(id);
+            if (record === false) {
+                return res.status(404).send({
+                    status: 404,
+                    message: 'Red-flag not found',
+                });
+            }
+            const modifiedRecord = await Model.modifyLocation(record, req.body.location);
+            return res.status(200).send({
+                status: 200,
+                data: [{
+                    id: modifiedRecord.id,
+                    message: 'updated red-flag record\'s location',
+                }],
+            });
+        } catch (error) {
+            return res.status(404).send({
                 message: error,
             });
         }

--- a/server/model/model.js
+++ b/server/model/model.js
@@ -55,6 +55,21 @@ class Model {
         };
         return incidents.push(newIncident);
     }
+
+    /**
+     * @static modifyLocation
+     * @param {*} record
+     * @param {*} newLocation
+     * @returns {object} incident
+     */
+    static modifyLocation(record, newLocation) {
+        const incident = record;
+        const location = newLocation;
+
+        incident.location = location;
+
+        return incident;
+    }
 }
 
 export default Model;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -8,5 +8,6 @@ const router = express.Router();
 router.get('/', Incidents.allIncidents);
 router.get('/:id', Incidents.oneIncident);
 router.post('/', Incidents.createIncident);
+router.patch('/:id/location', Incidents.modifyIncidentLocation);
 
 export default router;

--- a/test/test.js
+++ b/test/test.js
@@ -51,7 +51,7 @@ describe('POST API endpoint', () => {
             .end((err, res) => {
                 expect(res).to.have.status(201);
                 expect(res.body).to.be.an('object');
-                expect(res.body).to.have.property('status').to.be.an('number');
+                expect(res.body).to.have.property('status').to.be.a('number');
                 expect(res.body).to.have.property('data').to.be.an('array');
                 expect(res.body.data[0]).to.have.property('id');
                 expect(res.body.data[0]).to.have.property('message').to.be.equal('Created red-flag record');
@@ -70,12 +70,11 @@ describe('PATCH API endpoint /red-flags/<red-flag-id>/location', () => {
             })
             .end((err, res) => {
                 expect(res).to.have.status(200);
-                expect(res).to.be.a.json();
                 expect(res.body).to.be.an('object');
-                expect(res.body).to.have.property('status').to.be.an('int');
+                expect(res.body).to.have.property('status').to.be.a('number');
                 expect(res.body).to.have.property('data').to.be.an('array');
-                expect(res.body.data).to.have.property('id');
-                expect(res.body.data).to.have.property('message').to.be.equal.to('Updated red-flag record’s location');
+                expect(res.body.data[0]).to.have.property('id');
+                expect(res.body.data[0]).to.have.property('message').to.be.equal('updated red-flag record\'s location');
                 done();
             });
     });


### PR DESCRIPTION
**What does this PR do?**
Creates patch request endpoint '/api/v1/red-flags/:id/location' to modify location

**Description of tasks to be completed?**

- Write the model function to modify a red flag's location

- Write the controller function to modify a red flag's location

- Add route to modify a red flag's location

**How should this be tested?**

After cloning the repo, cd into the folder, checkout to the ft-modify-redflag-location-162183706 branch

- run npm start and send a patch request to 'http://localhost:3000/api/v1/red-flags/1/location' with postman with required body field - 'location'.

- run npm test

**What are the relevant pivotal tracker stories?**
#162183706