### PR TITLE
#162183693 Ft modify red flag comment 

### DIFF
--- a/server/controller/controller.js
+++ b/server/controller/controller.js
@@ -112,6 +112,37 @@ class Incidents {
             });
         }
     }
+
+    /**
+     * @async modifyIncidentComment
+     * @param {*} req
+     * @param {*} res
+     * @returns {object} modifiedRecord
+     */
+    static async modifyIncidentComment(req, res) {
+        const id = parseInt(req.params.id, 10);
+        try {
+            const record = await Model.getOne(id);
+            if (record === false) {
+                return res.status(404).send({
+                    status: 404,
+                    message: 'Red-flag not found',
+                });
+            }
+            const modifiedRecord = await Model.modifyComment(record, req.body.comment);
+            return res.status(200).send({
+                status: 200,
+                data: [{
+                    id: modifiedRecord.id,
+                    message: 'updated red-flag record\'s comment',
+                }],
+            });
+        } catch (error) {
+            return res.status(404).send({
+                message: error,
+            });
+        }
+    }
 }
 
 export default Incidents;

--- a/server/model/model.js
+++ b/server/model/model.js
@@ -70,6 +70,21 @@ class Model {
 
         return incident;
     }
+
+    /**
+     * @static modifyComment
+     * @param {*} record
+     * @param {*} newComment
+     * @returns {object} incident
+     */
+    static modifyComment(record, newComment) {
+        const incident = record;
+        const comment = newComment;
+
+        incident.comment = comment;
+
+        return incident;
+    }
 }
 
 export default Model;

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -9,5 +9,6 @@ router.get('/', Incidents.allIncidents);
 router.get('/:id', Incidents.oneIncident);
 router.post('/', Incidents.createIncident);
 router.patch('/:id/location', Incidents.modifyIncidentLocation);
+router.patch('/:id/comment', Incidents.modifyIncidentComment);
 
 export default router;

--- a/test/test.js
+++ b/test/test.js
@@ -90,12 +90,11 @@ describe('PATCH API endpoint /red-flags/<red-flag-id>/comment', () => {
             })
             .end((err, res) => {
                 expect(res).to.have.status(200);
-                expect(res).to.be.a.json();
                 expect(res.body).to.be.an('object');
-                expect(res.body).to.have.property('status').to.be.an('int');
+                expect(res.body).to.have.property('status').to.be.an('number');
                 expect(res.body).to.have.property('data').to.be.an('array');
-                expect(res.body.data).to.have.property('id');
-                expect(res.body.data).to.have.property('message').to.be.equal.to('Updated red-flag record’s comment');
+                expect(res.body.data[0]).to.have.property('id');
+                expect(res.body.data[0]).to.have.property('message').to.be.equal('updated red-flag record\'s comment');
                 done();
             });
     });


### PR DESCRIPTION
**What does this PR do?**
Creates patch request endpoint '/api/v1/red-flags/:id/comment' to modify comment

**Description of tasks to be completed?**
- Write the model function to modify a red flag's comment

- Write the controller function to modify a red flag's comment

- Add route to modify a red flag's comment

**How should this be tested?**
After cloning the repo, cd into the folder, checkout to the ft-modify-redflag-comment-162183693 branch

- run npm start and send a patch request to 'http://localhost:3000/api/v1/red-flags/1/comment' with postman with required body field - 'comment'.

- run npm test

**What are the relevant pivotal tracker stories?**
#162183693