### PR TITLE
#162470402 Create add intervention route

### DIFF
--- a/server/controller/redflagController.js
+++ b/server/controller/redflagController.js
@@ -10,6 +10,8 @@ class Records {
      * @returns {object}
      */
     static async createRecord(req, res) {
+        const returnmessage = req.message;
+
         try {
             const newRecord = await Model.create(
                 req.userId,
@@ -23,7 +25,7 @@ class Records {
                 status: 201,
                 data: [{
                     id: newRecord.id,
-                    message: 'Created red-flag record',
+                    message: `Created ${returnmessage} record`,
                     record: newRecord,
                 },
                 ],

--- a/server/middleware/message.js
+++ b/server/middleware/message.js
@@ -1,0 +1,13 @@
+// Middle ware to differentiate between a redflag and intervention
+
+const intervention = (req, res, next) => {
+    req.message = 'intervention';
+    return next();
+};
+
+const redflag = (req, res, next) => {
+    req.message = 'red-flag';
+    return next();
+};
+
+export { redflag, intervention };

--- a/server/middleware/validateInput.js
+++ b/server/middleware/validateInput.js
@@ -22,10 +22,20 @@ const signin = [
 ];
 
 // Validate create record input
-const record = [
+const redflagInput = [
     body('type', 'Type is required').exists(),
 
-    body('type', 'type should be either \'red flag\' or \'intervention\'').isIn('red flag', 'intervention'),
+    body('type', 'Type must be \'red flag\'').equals('red flag'),
+
+    body('location', 'Location is required').exists(),
+
+    body('comment', 'Comment is required').exists().isLength({ min: 10 }),
+];
+
+const interventionInput = [
+    body('type', 'Type is required').exists(),
+
+    body('type', 'Type must be \'intervention\'').equals('intervention'),
 
     body('location', 'Location is required').exists(),
 
@@ -60,5 +70,12 @@ const validationHandler = (req, res, next) => {
 
 
 export {
-    signUp, signin, record, updateLocation, updateComment, parameter, validationHandler,
+    signUp,
+    signin,
+    redflagInput,
+    interventionInput,
+    updateLocation,
+    updateComment,
+    parameter,
+    validationHandler,
 };

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -5,6 +5,7 @@ import User from '../controller/userController';
 import Records from '../controller/redflagController';
 import Auth from '../middleware/auth';
 import * as Validate from '../middleware/validateInput';
+import * as Message from '../middleware/message';
 
 const router = express.Router();
 
@@ -12,9 +13,10 @@ const router = express.Router();
 // Red flag routes
 router.post(
     '/red-flags/',
-    Validate.record,
+    Validate.redflagInput,
     Validate.validationHandler,
     Auth,
+    Message.redflag,
     Records.createRecord,
 );
 
@@ -51,6 +53,16 @@ router.delete(
     '/red-flags/:id',
     Auth,
     Records.deleteRedflag,
+);
+
+// Intervention routes
+router.post(
+    '/intervention',
+    Validate.interventionInput,
+    Validate.validationHandler,
+    Auth,
+    Message.intervention,
+    Records.createRecord,
 );
 
 

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -38,7 +38,10 @@ describe('before testing', () => {
                 });
         });
 
-        // Test POST endpoint
+        /**
+         * Test POST endpoints
+         */
+        // Test POST red flag endpoint
         describe('POST API endpoint api/v1/red-flags', () => {
             it('POST a report', (done) => {
                 chai.request(app)
@@ -120,6 +123,99 @@ describe('before testing', () => {
                     .set('x-access-token', token)
                     .send({
                         type: 'red flag',
+                        location: 'gwagwalada',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+        });
+
+        // Test POST intervention endpoint
+        describe('POST API endpoint api/v1/intervention', () => {
+            it('POST a report', (done) => {
+                chai.request(app)
+                    .post('/api/v1/intervention')
+                    .set('x-access-token', token)
+                    .send({
+                        type: 'intervention',
+                        location: 'gwagwalada',
+                        // eslint-disable-next-line no-useless-escape
+                        images: '{\"img.png\"}',
+                        comment: 'plenty comments',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(201);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.a('number');
+                        expect(res.body).to.have.property('data').to.be.an('array');
+                        expect(res.body.data[0]).to.have.property('id');
+                        expect(res.body.data[0]).to.have.property('message').to.be.equal('Created intervention record');
+                        redflagId = res.body.data[0].id;
+                        done();
+                    });
+            });
+
+            it('return error when type is not provided', (done) => {
+                chai.request(app)
+                    .post('/api/v1/intervention')
+                    .set('x-access-token', token)
+                    .send({
+                        location: 'gwagwalada',
+                        // eslint-disable-next-line no-useless-escape
+                        images: '{\"img.png\"}',
+                        comment: 'plenty comments',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+
+            it('return error when type wrong', (done) => {
+                chai.request(app)
+                    .post('/api/v1/intervention')
+                    .set('x-access-token', token)
+                    .send({
+                        type: 'record',
+                        location: 'gwagwalada',
+                        comment: 'plenty comments',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+
+            it('return error when location is not provided', (done) => {
+                chai.request(app)
+                    .post('/api/v1/intervention')
+                    .set('x-access-token', token)
+                    .send({
+                        type: 'intervention',
+                        comment: 'plenty comments',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+
+            it('return error when comment is not provided', (done) => {
+                chai.request(app)
+                    .post('/api/v1/intervention')
+                    .set('x-access-token', token)
+                    .send({
+                        type: 'intervention',
                         location: 'gwagwalada',
                     })
                     .end((err, res) => {


### PR DESCRIPTION
**What does this PR do?**
Creates the add interventions route

**Description of work done?**
- Create route
- Modify records controller to handle both red flags and interventions
- Create message middleware to customize messages
- Write tests for route

**How can this be tested?**
After cloning the repo, cd into the folder,  checkout to the ft-create-add-intervention-route-162470402 branch
- run npm start and send a POST request with required fields to 'http://localhost:3000/api/v1/interventions' in postman

- run npm test

**What are the relevant PT stories**
#162470402