### PR TITLE
#162470457 Update intervention location 

### DIFF
--- a/server/controller/redflagController.js
+++ b/server/controller/redflagController.js
@@ -124,7 +124,7 @@ class Records {
 
             return res.status(200).send({
                 status: 200,
-                message: 'Updated red-flag record\'s location',
+                message: `Updated ${returnmessage} record's location`,
                 data: updatedLocation,
             });
         } catch (error) {

--- a/server/controller/redflagController.js
+++ b/server/controller/redflagController.js
@@ -106,14 +106,19 @@ class Records {
      * @param {*} res
      * @returns {object}
      */
-    static async updateRedflagLocation(req, res) {
+    static async updateRecordLocation(req, res) {
+        const returnmessage = req.message;
         try {
-            const updatedLocation = await Model.updateLocation(req.params.id, req.body.location);
+            const updatedLocation = await Model.updateLocation(
+                req.params.id,
+                req.body.location,
+                returnmessage,
+            );
 
             if (!updatedLocation) {
                 return res.status(404).send({
                     status: 404,
-                    message: 'Red-flag not found',
+                    message: `${returnmessage} not found`,
                 });
             }
 

--- a/server/model/recordsModel.js
+++ b/server/model/recordsModel.js
@@ -76,9 +76,9 @@ class Model {
      * @param {*} location
      * @returns {object}
      */
-    static async updateLocation(recordId, location) {
-        const sql = 'UPDATE records SET location = $1 WHERE id = $2 RETURNING id, location';
-        const values = [location, recordId];
+    static async updateLocation(recordId, location, type) {
+        const sql = 'UPDATE records SET location = $1 WHERE id = $2 AND type = $3 RETURNING id, location';
+        const values = [location, recordId, type];
 
         const { rows } = await pool.query(sql, values);
         return rows[0];

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -39,7 +39,8 @@ router.patch(
     Validate.updateLocation,
     Validate.validationHandler,
     Auth,
-    Records.updateRedflagLocation,
+    Message.redflag,
+    Records.updateRecordLocation,
 );
 
 router.patch(
@@ -78,6 +79,15 @@ router.get(
     Auth,
     Message.intervention,
     Records.getOneRecord,
+);
+
+router.patch(
+    '/interventions/:id/location',
+    Validate.updateLocation,
+    Validate.validationHandler,
+    Auth,
+    Message.intervention,
+    Records.updateRecordLocation,
 );
 
 // User routes

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -319,6 +319,9 @@ describe('before testing', () => {
             });
         });
 
+        /**
+         * Test PATCH location endpoints
+         */
         // Test PATCH location of red flag endpoint
         describe('PATCH API endpoint /red-flags/<red-flag-id>/location', () => {
             it('should update location of red flag', (done) => {
@@ -332,7 +335,7 @@ describe('before testing', () => {
                         expect(res).to.have.status(200);
                         expect(res.body).to.be.an('object');
                         expect(res.body).to.have.property('status').to.be.a('number');
-                        expect(res.body).to.have.property('message').to.be.equal('Updated red-flag record\'s location');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated red flag record\'s location');
                         expect(res.body).to.have.property('data').to.be.an('object');
                         expect(res.body.data).to.have.property('id');
                         expect(res.body.data).to.have.property('location');
@@ -350,6 +353,28 @@ describe('before testing', () => {
                     .end((err, res) => {
                         expect(res).to.have.status(404);
                         expect(res.body).to.be.an('object');
+                        done();
+                    });
+            });
+        });
+
+        // Test PATCH location of red flag endpoint
+        describe('PATCH API endpoint /interventions/<interventions-id>/location', () => {
+            it('should update location of intervention', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/interventions/${interventionId}/location`)
+                    .set('x-access-token', token)
+                    .send({
+                        location: 'Lat: 500, Long: 70',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.a('number');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated intervention record\'s location');
+                        expect(res.body).to.have.property('data').to.be.an('object');
+                        expect(res.body.data).to.have.property('id');
+                        expect(res.body.data).to.have.property('location');
                         done();
                     });
             });


### PR DESCRIPTION
**What does this PR do?**
Creates a route to update intervention record location.

**Description of work done?**
- Write a test for update intervention route
 - Create route
- Modify model and controller functions to update intervention record location

**How can this be tested?**
After cloning the repo, cd into the folder,  checkout to the ft-update-intervention-location-162470457 branch
- run npm start and send a PATCH request with required location field to 'http://localhost:3000/api/v1/interventions/:id/location' in postman.
- run npm test

**What are the relevant PT stories**
#162470457