### PR TITLE
#162470462 Update intervention comment 

### DIFF
--- a/server/controller/redflagController.js
+++ b/server/controller/redflagController.js
@@ -140,20 +140,25 @@ class Records {
      * @param {*} res
      * @returns {object}
      */
-    static async updateRedflagComment(req, res) {
+    static async updateRecordComment(req, res) {
+        const returnmessage = req.message;
         try {
-            const updatedComment = await Model.updateComment(req.params.id, req.body.comment);
+            const updatedComment = await Model.updateComment(
+                req.params.id,
+                req.body.comment,
+                returnmessage,
+            );
 
             if (!updatedComment) {
                 return res.status(404).send({
                     status: 404,
-                    message: 'Red-flag not found',
+                    message: `${returnmessage} not found`,
                 });
             }
 
             return res.status(200).send({
                 status: 200,
-                message: 'Updated red-flag record\'s comment',
+                message: `Updated ${returnmessage} record's comment`,
                 data: updatedComment,
             });
         } catch (error) {

--- a/server/model/recordsModel.js
+++ b/server/model/recordsModel.js
@@ -90,9 +90,9 @@ class Model {
      * @param {*} comment
      * @returns {object}
      */
-    static async updateComment(recordId, comment) {
-        const sql = 'UPDATE records SET comment = $1 WHERE id = $2 RETURNING id, comment';
-        const values = [comment, recordId];
+    static async updateComment(recordId, comment, type) {
+        const sql = 'UPDATE records SET comment = $1 WHERE id = $2 AND type = $3 RETURNING id, comment';
+        const values = [comment, recordId, type];
 
         const { rows } = await pool.query(sql, values);
         return rows[0];

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -48,7 +48,8 @@ router.patch(
     Validate.updateComment,
     Validate.validationHandler,
     Auth,
-    Records.updateRedflagComment,
+    Message.redflag,
+    Records.updateRecordComment,
 );
 
 router.delete(
@@ -88,6 +89,15 @@ router.patch(
     Auth,
     Message.intervention,
     Records.updateRecordLocation,
+);
+
+router.patch(
+    '/interventions/:id/comment',
+    Validate.updateComment,
+    Validate.validationHandler,
+    Auth,
+    Message.intervention,
+    Records.updateRecordComment,
 );
 
 // User routes

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -380,6 +380,9 @@ describe('before testing', () => {
             });
         });
 
+        /**
+         * Test PATCH comment endpoints
+         */
         // Test PATCH comment of red flag endpoint
         describe('PATCH API endpoint /red-flags/<red-flag-id>/comment', () => {
             it('should update comment on a red flag', (done) => {
@@ -394,7 +397,7 @@ describe('before testing', () => {
                         expect(res.body).to.be.an('object');
                         expect(res.body).to.have.property('status').to.be.an('number');
                         expect(res.body).to.have.property('data').to.be.an('object');
-                        expect(res.body).to.have.property('message').to.be.equal('Updated red-flag record\'s comment');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated red flag record\'s comment');
                         expect(res.body.data).to.have.property('id');
                         expect(res.body.data).to.have.property('comment');
                         done();
@@ -411,6 +414,28 @@ describe('before testing', () => {
                     .end((err, res) => {
                         expect(res).to.have.status(404);
                         expect(res.body).to.be.an('object');
+                        done();
+                    });
+            });
+        });
+
+        // Test PATCH comment of intervention endpoint
+        describe('PATCH API endpoint /interventions/<interventions-id>/comment', () => {
+            it('should update comment on a intervention', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/interventions/${interventionId}/comment/`)
+                    .set('x-access-token', token)
+                    .send({
+                        comment: 'new comment',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.an('number');
+                        expect(res.body).to.have.property('data').to.be.an('object');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated intervention record\'s comment');
+                        expect(res.body.data).to.have.property('id');
+                        expect(res.body.data).to.have.property('comment');
                         done();
                     });
             });


### PR DESCRIPTION
**What does this PR do?**
Creates a route to update intervention record comment.

**Description of work done?**
- Write a test for update intervention comment route
- Create update intervention commen route
- Modify model and controller functions to update intervention record comment

**How can this be tested?**
After cloning the repo, cd into the folder, checkout to the ft-update-intervention-comment-162470462 branch
- run npm start and send a PATCH request with required comment field to 'http://localhost:3000/api/v1/interventions/:id/comment' in postman.
- run npm test

**What are the relevant PT stories**
#162470462