### PR TITLE
#162470467 Delete intervention record 

### DIFF
--- a/server/controller/redflagController.js
+++ b/server/controller/redflagController.js
@@ -174,20 +174,21 @@ class Records {
      * @param {*} res
      * @returns {object}
      */
-    static async deleteRedflag(req, res) {
+    static async deleteRecord(req, res) {
+        const returnmessage = req.message;
         try {
-            const deleteRedflag = await Model.delete(req.userId, req.params.id);
+            const deleteRedflag = await Model.delete(req.userId, req.params.id, returnmessage);
 
             if (!deleteRedflag) {
                 return res.status(404).send({
                     status: 404,
-                    message: 'Red-flag not found',
+                    message: `${returnmessage} not found`,
                 });
             }
 
             return res.status(200).send({
                 status: 200,
-                message: 'red-flag record has been deleted',
+                message: `${returnmessage} record has been deleted`,
                 data: deleteRedflag,
             });
         } catch (error) {

--- a/server/model/recordsModel.js
+++ b/server/model/recordsModel.js
@@ -104,9 +104,9 @@ class Model {
      * @param {*} recordId
      * @returns {object}
      */
-    static async delete(userId, recordId) {
-        const sql = 'DELETE FROM records WHERE createdBy = $1 AND id = $2 RETURNING id';
-        const values = [userId, recordId];
+    static async delete(userId, recordId, type) {
+        const sql = 'DELETE FROM records WHERE createdBy = $1 AND id = $2 AND type = $3 RETURNING id';
+        const values = [userId, recordId, type];
 
         const { rows } = await pool.query(sql, values);
         return rows[0];

--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -55,7 +55,8 @@ router.patch(
 router.delete(
     '/red-flags/:id',
     Auth,
-    Records.deleteRedflag,
+    Message.redflag,
+    Records.deleteRecord,
 );
 
 // Intervention routes
@@ -67,7 +68,6 @@ router.post(
     Message.intervention,
     Records.createRecord,
 );
-
 
 router.get(
     '/interventions',
@@ -98,6 +98,13 @@ router.patch(
     Auth,
     Message.intervention,
     Records.updateRecordComment,
+);
+
+router.delete(
+    '/interventions/:id',
+    Auth,
+    Message.intervention,
+    Records.deleteRecord,
 );
 
 // User routes

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -322,7 +322,7 @@ describe('before testing', () => {
         /**
          * Test PATCH location endpoints
          */
-        // Test PATCH location of red flag endpoint
+        // Test PATCH red flag location endpoint
         describe('PATCH API endpoint /red-flags/<red-flag-id>/location', () => {
             it('should update location of red flag', (done) => {
                 chai.request(app)
@@ -358,7 +358,7 @@ describe('before testing', () => {
             });
         });
 
-        // Test PATCH location of red flag endpoint
+        // Test PATCH intervention location endpoint
         describe('PATCH API endpoint /interventions/<interventions-id>/location', () => {
             it('should update location of intervention', (done) => {
                 chai.request(app)
@@ -383,7 +383,7 @@ describe('before testing', () => {
         /**
          * Test PATCH comment endpoints
          */
-        // Test PATCH comment of red flag endpoint
+        // Test PATCH red flag comment endpoint
         describe('PATCH API endpoint /red-flags/<red-flag-id>/comment', () => {
             it('should update comment on a red flag', (done) => {
                 chai.request(app)
@@ -419,7 +419,7 @@ describe('before testing', () => {
             });
         });
 
-        // Test PATCH comment of intervention endpoint
+        // Test PATCH intervention comment endpoint
         describe('PATCH API endpoint /interventions/<interventions-id>/comment', () => {
             it('should update comment on a intervention', (done) => {
                 chai.request(app)
@@ -441,9 +441,12 @@ describe('before testing', () => {
             });
         });
 
-        // Test DELETE incident endpoint
+        /**
+         * Test DELETE endpoints
+         */
+        // Test DELETE red flag endpoint
         describe('DELETE API endpoint /api/v1/red-flags/<red-flag-id>', () => {
-            it('should return all incidents', (done) => {
+            it('should delete red flag', (done) => {
                 chai.request(app)
                     .delete(`/api/v1/red-flags/${redflagId}`)
                     .set('x-access-token', token)
@@ -451,7 +454,7 @@ describe('before testing', () => {
                         expect(res).to.have.status(200);
                         expect(res.body).to.be.an('object');
                         expect(res.body).to.have.property('status').to.be.an('number');
-                        expect(res.body).to.have.property('message').to.be.equal('red-flag record has been deleted');
+                        expect(res.body).to.have.property('message').to.be.equal('red flag record has been deleted');
                         expect(res.body).to.have.property('data').to.be.an('object');
                         expect(res.body.data).to.have.property('id');
                         done();
@@ -461,6 +464,35 @@ describe('before testing', () => {
             it('should return error with invalid id', (done) => {
                 chai.request(app)
                     .delete('/api/v1/red-flags/3818ea1f-bb6c-43bf-9503-d48957c8a6d3')
+                    .set('x-access-token', token)
+                    .then((res) => {
+                        expect(res).to.have.status(404);
+                        expect(res.body).to.be.an('object');
+                        done();
+                    });
+            });
+        });
+
+        // Test DELETE intervention endpoint
+        describe('DELETE API endpoint /api/v1/interventions/<interventions-id>', () => {
+            it('should delete intervention', (done) => {
+                chai.request(app)
+                    .delete(`/api/v1/interventions/${interventionId}`)
+                    .set('x-access-token', token)
+                    .then((res) => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.an('number');
+                        expect(res.body).to.have.property('message').to.be.equal('intervention record has been deleted');
+                        expect(res.body).to.have.property('data').to.be.an('object');
+                        expect(res.body.data).to.have.property('id');
+                        done();
+                    });
+            });
+
+            it('should return error with invalid id', (done) => {
+                chai.request(app)
+                    .delete('/api/v1/interventions/3818ea1f-bb6c-43bf-9503-d48957c8a6d3')
                     .set('x-access-token', token)
                     .then((res) => {
                         expect(res).to.have.status(404);


### PR DESCRIPTION
**What does this PR do?**
Creates a route to delete intervention record.

**Description of work done?**
- Write a test for delete intervention route
- Create delete route
- Modify model and controller methods to delete intervention record

**How can this be tested?**
After cloning the repo, cd into the folder, checkout to the ft-delete-intervention-record-162470467  branch
- run npm start and send a DELETE request to 'http://localhost:3000/api/v1/interventions/:id' in postman.
- run npm test.

**What are the relevant PT stories**
#162470467 