### PR TITLE
#162470449 Update intervention status 

### DIFF
--- a/server/routes/routes.js
+++ b/server/routes/routes.js
@@ -111,6 +111,16 @@ router.patch(
     Records.updateRecordComment,
 );
 
+router.patch(
+    '/interventions/:id/status',
+    Validate.updateStatus,
+    Validate.validationHandler,
+    Auth,
+    isAdmin,
+    Message.intervention,
+    Records.updateRecordStatus,
+);
+
 router.delete(
     '/interventions/:id',
     Auth,

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -470,7 +470,7 @@ describe('before testing', () => {
         describe('PATCH API endpoint /red-flags/<red-flag-id>/status', () => {
             it('should update status on a red flag', (done) => {
                 chai.request(app)
-                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .patch(`/api/v1/red-flags/${redflagId}/status/`)
                     .set('x-access-token', admintoken)
                     .send({
                         status: 'resolved',
@@ -556,7 +556,7 @@ describe('before testing', () => {
 
             it('should return forbidden', (done) => {
                 chai.request(app)
-                    .patch(`/api/v1/red-flag/${interventionId}/status/`)
+                    .patch(`/api/v1/interventions/${interventionId}/status/`)
                     .set('x-access-token', token)
                     .send({
                         status: 'resolved',

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -9,8 +9,8 @@ import * as schema from '../server/db/dbschema';
 chai.use(chaiHttp);
 
 let token;
+let admintoken;
 let redflagId;
-// eslint-disable-next-line no-unused-vars
 let interventionId;
 
 describe('before testing', () => {
@@ -36,6 +36,28 @@ describe('before testing', () => {
                     expect(res.body.data[0]).to.have.property('token');
                     // eslint-disable-next-line prefer-destructuring
                     token = res.body.data[0].token;
+                    done();
+                });
+        });
+
+        it('sign up user and return token', (done) => {
+            chai.request(app)
+                .post('/api/v1/auth/signup')
+                .send({
+                    firstname: 'Adaeze',
+                    lastname: 'Eric',
+                    username: 'deeEric',
+                    email: 'daizyodurukwe@gmail.com',
+                    password: 'puma',
+                    phone: '08136770975',
+                    isadmin: true,
+                })
+                .end((err, res) => {
+                    expect(res).to.have.status(201);
+                    expect(res.body).to.be.a('object');
+                    expect(res.body.data[0]).to.have.property('token');
+                    // eslint-disable-next-line prefer-destructuring
+                    admintoken = res.body.data[0].token;
                     done();
                 });
         });
@@ -436,6 +458,53 @@ describe('before testing', () => {
                         expect(res.body).to.have.property('message').to.be.equal('Updated intervention record\'s comment');
                         expect(res.body.data).to.have.property('id');
                         expect(res.body.data).to.have.property('comment');
+                        done();
+                    });
+            });
+        });
+
+        /**
+         * Test PATCH status endpoints
+         */
+        // Test update redflag status endpoint
+        describe('PATCH API endpoint /red-flag/<red-flag-id>/status', () => {
+            it('should update status on a red flag', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .set('x-access-token', admintoken)
+                    .send({
+                        status: 'new status',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.a('number');
+                        expect(res.body).to.have.property('data').to.be.an('object');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated red flag record\'s status');
+                        expect(res.body.data).to.have.property('id');
+                        expect(res.body.data).to.have.property('status');
+                        done();
+                    });
+            });
+        });
+
+        // Test update intervention status
+        describe('PATCH API endpoint /interventions/<interventions-id>/status', () => {
+            it('should update status on an intervention', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/interventions/${interventionId}/status/`)
+                    .set('x-access-token', admintoken)
+                    .send({
+                        status: 'new status',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(200);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('status').to.be.a('number');
+                        expect(res.body).to.have.property('data').to.be.an('object');
+                        expect(res.body).to.have.property('message').to.be.equal('Updated intervention record\'s status');
+                        expect(res.body.data).to.have.property('id');
+                        expect(res.body.data).to.have.property('status');
                         done();
                     });
             });

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -467,7 +467,7 @@ describe('before testing', () => {
          * Test PATCH status endpoints
          */
         // Test update redflag status endpoint
-        describe('PATCH API endpoint /red-flag/<red-flag-id>/status', () => {
+        describe('PATCH API endpoint /red-flags/<red-flag-id>/status', () => {
             it('should update status on a red flag', (done) => {
                 chai.request(app)
                     .patch(`/api/v1/red-flag/${redflagId}/status/`)
@@ -489,7 +489,7 @@ describe('before testing', () => {
 
             it('should return error for incorrect status type', (done) => {
                 chai.request(app)
-                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .patch(`/api/v1/red-flags/${redflagId}/status/`)
                     .set('x-access-token', admintoken)
                     .send({
                         status: 'resolve',
@@ -504,7 +504,7 @@ describe('before testing', () => {
 
             it('should return forbidden', (done) => {
                 chai.request(app)
-                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .patch(`/api/v1/red-flags/${redflagId}/status/`)
                     .set('x-access-token', token)
                     .send({
                         status: 'resolved',
@@ -544,7 +544,7 @@ describe('before testing', () => {
                     .patch(`/api/v1/interventions/${interventionId}/status/`)
                     .set('x-access-token', admintoken)
                     .send({
-                        status: 'under',
+                        status: 'unders',
                     })
                     .end((err, res) => {
                         expect(res).to.have.status(422);

--- a/test/recordstest.js
+++ b/test/recordstest.js
@@ -473,7 +473,7 @@ describe('before testing', () => {
                     .patch(`/api/v1/red-flag/${redflagId}/status/`)
                     .set('x-access-token', admintoken)
                     .send({
-                        status: 'new status',
+                        status: 'resolved',
                     })
                     .end((err, res) => {
                         expect(res).to.have.status(200);
@@ -486,16 +486,46 @@ describe('before testing', () => {
                         done();
                     });
             });
+
+            it('should return error for incorrect status type', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .set('x-access-token', admintoken)
+                    .send({
+                        status: 'resolve',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+
+            it('should return forbidden', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/red-flag/${redflagId}/status/`)
+                    .set('x-access-token', token)
+                    .send({
+                        status: 'resolved',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(403);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('message').to.be.equals('forbidden');
+                        done();
+                    });
+            });
         });
 
-        // Test update intervention status
+        // Test update intervention status endpoint
         describe('PATCH API endpoint /interventions/<interventions-id>/status', () => {
             it('should update status on an intervention', (done) => {
                 chai.request(app)
                     .patch(`/api/v1/interventions/${interventionId}/status/`)
                     .set('x-access-token', admintoken)
                     .send({
-                        status: 'new status',
+                        status: 'under investigation',
                     })
                     .end((err, res) => {
                         expect(res).to.have.status(200);
@@ -505,6 +535,36 @@ describe('before testing', () => {
                         expect(res.body).to.have.property('message').to.be.equal('Updated intervention record\'s status');
                         expect(res.body.data).to.have.property('id');
                         expect(res.body.data).to.have.property('status');
+                        done();
+                    });
+            });
+
+            it('should return error for incorrect status type', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/interventions/${interventionId}/status/`)
+                    .set('x-access-token', admintoken)
+                    .send({
+                        status: 'under',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(422);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('errors').to.be.an('array');
+                        done();
+                    });
+            });
+
+            it('should return forbidden', (done) => {
+                chai.request(app)
+                    .patch(`/api/v1/red-flag/${interventionId}/status/`)
+                    .set('x-access-token', token)
+                    .send({
+                        status: 'resolved',
+                    })
+                    .end((err, res) => {
+                        expect(res).to.have.status(403);
+                        expect(res.body).to.be.an('object');
+                        expect(res.body).to.have.property('message').to.be.equals('forbidden');
                         done();
                     });
             });


### PR DESCRIPTION
**What does this PR do?**
Creates a route to update intervention status

**Description of work done?**
- Create update intervention status route
- Write tests for update status routes

**How can this be tested?**
After cloning the repo, cd into the folder, checkout to the ft-update-interventions-status-162470449  branch
- run npm start and send PATCH request with required status field to 'http://localhost:3000/api/v1/interventions/:id/status' in postman

**What are the relevant PT stories**
#162470449